### PR TITLE
reduced overhead of `MDB_RESERVE`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
@@ -209,11 +209,10 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heed"
-version = "0.20.0-alpha.4"
-source = "git+https://github.com/meilisearch/heed?branch=put-reserved-maybe-uninit#584a274f3076906538ffee4ba0080cac99acf60f"
+version = "0.20.0"
+source = "git+https://github.com/nolanderc/heed?rev=cab1ab1d059c608404a6d26e939ad45a4ec4d18c#cab1ab1d059c608404a6d26e939ad45a4ec4d18c"
 dependencies = [
  "bitflags",
- "bytemuck",
  "byteorder",
  "heed-traits",
  "heed-types",
@@ -241,16 +240,15 @@ dependencies = [
 
 [[package]]
 name = "heed-traits"
-version = "0.20.0-alpha.4"
-source = "git+https://github.com/meilisearch/heed?branch=put-reserved-maybe-uninit#584a274f3076906538ffee4ba0080cac99acf60f"
+version = "0.20.0"
+source = "git+https://github.com/nolanderc/heed?rev=cab1ab1d059c608404a6d26e939ad45a4ec4d18c#cab1ab1d059c608404a6d26e939ad45a4ec4d18c"
 
 [[package]]
 name = "heed-types"
-version = "0.20.0-alpha.4"
-source = "git+https://github.com/meilisearch/heed?branch=put-reserved-maybe-uninit#584a274f3076906538ffee4ba0080cac99acf60f"
+version = "0.20.0"
+source = "git+https://github.com/nolanderc/heed?rev=cab1ab1d059c608404a6d26e939ad45a4ec4d18c#cab1ab1d059c608404a6d26e939ad45a4ec4d18c"
 dependencies = [
  "bincode",
- "bytemuck",
  "byteorder",
  "heed-traits",
  "serde",
@@ -281,8 +279,8 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "lmdb-master-sys"
-version = "0.1.0"
-source = "git+https://github.com/meilisearch/heed?branch=put-reserved-maybe-uninit#584a274f3076906538ffee4ba0080cac99acf60f"
+version = "0.2.0"
+source = "git+https://github.com/nolanderc/heed?rev=cab1ab1d059c608404a6d26e939ad45a4ec4d18c#cab1ab1d059c608404a6d26e939ad45a4ec4d18c"
 dependencies = [
  "cc",
  "doxygen-rs",
@@ -297,9 +295,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "page_size"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7663cbd190cfd818d08efa8497f6cd383076688c49a391ef7c0d03cd12b561"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
@@ -388,8 +386,8 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "roaring"
-version = "0.10.2"
-source = "git+https://github.com/RoaringBitmap/roaring-rs?branch=serialize-into-slice#c69f6f1c7a4af7564289305d6652cb00df398daf"
+version = "0.10.4"
+source = "git+https://github.com/RoaringBitmap/roaring-rs#3fa2e731dc773b6ce92968f50ee75cad80f546e5"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [profile.release]
+opt-level = 3
 debug = true
 
 [dependencies]
@@ -11,8 +12,8 @@ anyhow = "1.0.75"
 clap = { version = "4.4.7", features = ["derive"] }
 fastrand = "2.0.1"
 # heed = "0.20.0-alpha.4"
-heed = { git = "https://github.com/meilisearch/heed", branch = "put-reserved-maybe-uninit" }
+heed = { git = "https://github.com/nolanderc/heed", rev = "cab1ab1d059c608404a6d26e939ad45a4ec4d18c" }
 # roaring = "0.10.2"
-roaring = { git = "https://github.com/RoaringBitmap/roaring-rs", branch = "serialize-into-slice" }
+roaring = { git = "https://github.com/RoaringBitmap/roaring-rs" }
 serde_json = "1.0.108"
 uuid = { version = "1.5.0", features = ["v5", "v4"] }

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,14 @@
-#! /bin/bash
-set -ve
+#!/usr/bin/env bash
 
-cargo build --release
+(set -x; cargo build --release)
 
-./target/release/heed-perfs-put-reserved classic-codec
-./target/release/heed-perfs-put-reserved put-reserved
-./target/release/heed-perfs-put-reserved put-reserved-uninit
-./target/release/heed-perfs-put-reserved put-reserved-uninit-into-slice
+exe="./target/release/heed-perfs-put-reserved"
+
+for codec in classic-codec put-reserved put-reserved-alloc put-reserved-uninit put-reserved-uninit-fill-zeroes put-reserved-uninit-into-slice; do
+    # (set -x; flamegraph --root -o "flamegraphs/$codec-flamegraph.svg" -- $exe $codec)
+    # (set -x; sudo perf stat -- $exe $codec)
+    (set -x; $exe $codec)
+done
+
+rm -r *.mdb
+


### PR DESCRIPTION
See also my changes here https://github.com/nolanderc/heed/tree/reserved-space.

- use `#[inline]` on `ReservedSpace` to enable inlining across crates. It is also possible to use `lto = "thin"` or `lto = true` under `[profile.release]`.
- Made it possible to write into `&[MaybeUninit<u8>]` without UB using `UninitWriter`.

Seems `std::io::Write for &mut [u8]` is slower than expected. In my experiments, moving the check for `buf.len() > space.remaining()` as early as possible in the `write` function improved performance drastically (2x faster).

Test results on my laptop:

```sh
$ ./run.sh
+ ./target/release/heed-perfs-put-reserved classic-codec
  19.61s [insert:    8.04s, commit:   11.57s]
+ ./target/release/heed-perfs-put-reserved put-reserved
  19.37s [insert:    7.74s, commit:   11.62s]
+ ./target/release/heed-perfs-put-reserved put-reserved-alloc
  20.05s [insert:    8.83s, commit:   11.22s]
+ ./target/release/heed-perfs-put-reserved put-reserved-uninit
  18.57s [insert:    6.66s, commit:   11.91s]
+ ./target/release/heed-perfs-put-reserved put-reserved-uninit-fill-zeroes
  19.00s [insert:    7.10s, commit:   11.90s]
+ ./target/release/heed-perfs-put-reserved put-reserved-uninit-into-slice
  26.32s [insert:   15.40s, commit:   10.92s]
```

There's not a huge improvement over just pre-allocating a `Vec`, but yielded a 1.6s reduction in insertion time at its best. But this is a small benchmark where all data is the same size, which is also done on my laptop, so YMMV.